### PR TITLE
Su bin

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -33,6 +33,8 @@ perception:
 
   # Cone geometric constraints
   lidar_cone_detection:
+    cone_min_height: 0.1
+    cone_max_height: 0.5
     cone_min_radius: 0.00
     cone_max_radius: 0.7
     cone_min_points: 1

--- a/formula_autonomous_system.cpp
+++ b/formula_autonomous_system.cpp
@@ -285,12 +285,15 @@ bool Clustering::isValidCone(const std::vector<int>& cluster_indices,
     if (cluster_indices.size() < params_->lidar_cone_detection_min_points_) 
         is_valid = false; // Too few points
     
-    // Calculate height range
+    // Calculate cone detection range
     float min_x = std::numeric_limits<float>::max();
     float max_x = std::numeric_limits<float>::lowest();
 
     float min_y = std::numeric_limits<float>::max();
     float max_y = std::numeric_limits<float>::lowest();
+
+    float min_z = std::numeric_limits<float>::max();
+    float max_z = std::numeric_limits<float>::lowest();
 
     for (int idx : cluster_indices) {
         min_x = std::min(min_x, cloud->points[idx].x);
@@ -298,6 +301,15 @@ bool Clustering::isValidCone(const std::vector<int>& cluster_indices,
 
         min_y = std::min(min_y, cloud->points[idx].y);
         max_y = std::max(max_y, cloud->points[idx].y);
+
+        min_z = std::min(min_z, cloud->points[idx].z);
+        max_z = std::max(max_z, cloud->points[idx].z);
+    }
+
+    float height = max_z - min_z;
+    
+    if (height < params_->lidar_cone_detection_min_height_ || height > params_->lidar_cone_detection_max_height_) {
+        is_valid = false;
     }
     
     float x_range = max_x - min_x;

--- a/formula_autonomous_system.hpp
+++ b/formula_autonomous_system.hpp
@@ -1201,6 +1201,8 @@ struct PerceptionParams
         if(!pnh.getParam("/perception/lidar_clustering/dbscan_min_points", lidar_dbscan_min_points_)){std::cerr<<"Param perception/lidar_clustering/dbscan_min_points has error" << std::endl; return false;}
 
         // LiDAR Cone Detection
+        if(!pnh.getParam("/perception/lidar_cone_detection/cone_min_height", lidar_cone_detection_min_height_)){std::cerr<<"Param perception/lidar_cone_detection/cone_min_height has error" << std::endl; return false;}
+        if(!pnh.getParam("/perception/lidar_cone_detection/cone_max_height", lidar_cone_detection_max_height_)){std::cerr<<"Param perception/lidar_cone_detection/cone_max_height has error" << std::endl; return false;}
         if(!pnh.getParam("/perception/lidar_cone_detection/cone_min_radius", lidar_cone_detection_min_radius_)){std::cerr<<"Param perception/lidar_cone_detection/cone_min_radius has error" << std::endl; return false;}
         if(!pnh.getParam("/perception/lidar_cone_detection/cone_max_radius", lidar_cone_detection_max_radius_)){std::cerr<<"Param perception/lidar_cone_detection/cone_max_radius has error" << std::endl; return false;}
         if(!pnh.getParam("/perception/lidar_cone_detection/cone_min_points", lidar_cone_detection_min_points_)){std::cerr<<"Param perception/lidar_cone_detection/cone_min_points has error" << std::endl; return false;}

--- a/formula_autonomous_system_node.hpp
+++ b/formula_autonomous_system_node.hpp
@@ -135,6 +135,7 @@ public: // Function components
     void publishDetectedConesMarker();
     void publishProjectedConesImage();
     void publishCenterLineMarker();
+    void publishGlobalConesMarker();
     void publishLaneMarker();
     
 
@@ -189,6 +190,7 @@ public: // ROS
     ros::Publisher projected_cones_image_pub_;
     ros::Publisher center_line_marker_pub_;
     ros::Publisher lap_count_marker_pub_;
+    ros::Publisher global_cones_marker_pub_;
     ros::Publisher lane_marker_pub_;
 
     // Output messages


### PR DESCRIPTION
feat(Clustering): 콘을 판별하는 isValidCone 함수의 정확도를 향상
기존 로직은 클러스터의 포인트 개수와 수평 반경만을 고려하여, 낮은 연석이나 다른 장애물 일부를 콘으로 잘못 인식하는 경우가 있었습니다.

주요 변경 사항:
- config.yaml에 lidar_cone_detection 파라미터로 cone_min_height와 cone_max_height를 추가했습니다.
- Clustering::isValidCone 함수 내에서 클러스터의 z축 높이를 계산하고, 이 값이 설정된 최소/최대 높이 범위 내에 있을 때만 유효한 콘으로 판단하도록 필터링 로직을 추가했습니다.

기대 효과:
- 콘의 물리적 특성(높이)을 추가로 검사하여, 콘이 아닌 객체를 필터링하는 능력이 향상되었습니다.
- 맵 데이터의 정밀도를 높이고, 잘못된 장애물 정보로 인한 경로 계획 오류 가능성을 줄입니다.

feat(Visualization): 전역 트랙 맵 및 차선 시각화 기능 추가
Rviz에서 전체 트랙의 형상을 확인할 수 있도록, 누적된 콘 메모리(cone_memory_)를 기반으로 한 전역 맵 시각화 기능을 구현합니다. 이를 통해 맵 생성(Mapping) 과정의 정확성을 직관적으로 디버깅하고 검증할 수 있습니다.

주요 변경 사항:
- 전역 차선 시각화: MapManager가 생성한 차선을 스플라인 보간법으로 부드럽게 처리하여 /fsds/lane_marker 토픽으로 발행합니다. (frame: "map")
- 전역 콘 시각화: cone_memory_에 저장된 모든 콘의 위치를 /fsds/global_cones_marker 토픽으로 발행하여 차선과 함께 확인할 수 있도록 합니다. (frame: "map")


