### PR TITLE
MAPPING/RACING 모드 파라미터 분리 및 전역 경로 생성 로직 고도화

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -131,7 +131,7 @@ mapping:
 
   # Cone sorting parameters for lane generation
   max_connection_distance: 15.0
-  direction_weight: 0.5 # Path direction consistency weight (0.0 ~1.0)
+  direction_weight: 0.5 # Path direction consistency weight (0.0 ~ 1.0)
 
   # Cone map refinement parameters
   max_dist_from_lane: 2.0
@@ -140,33 +140,25 @@ mapping:
 # Planning Parameters
 # ===========================================
 planning:
-  trajectory:
-    # Basic trajectory generation
-    lookahead_distance: 3.0
-    waypoint_spacing: 0.2
-    default_speed: 3.0 # StopTrajectory
-    
-    # Cone-based path planning (meters)
-    max_cone_distance: 25.0
-    lane_offset: 2.0
-    
-    # Safety parameters (meters)
-    safety_margin: 0.5
+  trajectory_generation:
+    # Parameters used during the MAPPING lap
+    mapping_mode:
+      lookahead_distance: 3.0
+      waypoint_spacing: 0.2
+      max_speed: 3.0
+      lane_offset: 2.0
 
-    # Curvature-based speed planning
-    max_speed: 3.0
-    min_speed: 1.0
-    curvature_gain: 5.0
+    # Parameters used during the RACING laps
+    racing_mode:
+      lookahead_distance: 15.0
+      waypoint_spacing: 0.5
+      max_speed: 10.0
+      min_speed: 3.0
+      curvature_gain: 1.5
 
-  behavior:
+  behavioral_logic:
     # Lap Counting & Race Logic
-    # total laps based on KSAE FSD rules
-    # total_laps includes the mapping lap (e.g. 10 laps = 1 mapping lap + 9 racing laps)
-    total_laps: 10 # [laps]
-
-    # Dynamic Start/Finish Line Detection (meters)
-    min_y_separation: 5.0  # track width
-    max_x_separation: 2.0  # cone offset
+    total_laps: 10
 
 # ===========================================
 # Control Parameters
@@ -174,7 +166,7 @@ planning:
 control:
   ControllerSelection:
     # lateral_controller_type: "PurePursuit", "Stanley"
-    lateral_controller_type: "Stanley" 
+    lateral_controller_type: "Stanley"
 
   PurePursuit:
     lookahead_distance: 5.0

--- a/config.yaml
+++ b/config.yaml
@@ -142,8 +142,8 @@ mapping:
 planning:
   trajectory:
     # Basic trajectory generation
-    lookahead_distance: 20.0
-    waypoint_spacing: 0.5
+    lookahead_distance: 3.0
+    waypoint_spacing: 0.2
     default_speed: 3.0 # StopTrajectory
     
     # Cone-based path planning (meters)
@@ -181,9 +181,9 @@ control:
     max_steer_angle: 1.0
 
   Stanley:
-    k_gain: 0.6
+    k_gain: 0.9
     k_gain_curvature_boost: 1.2
-    alpha: 0.5 # (stability(0.0) <---> response(1.0))
+    alpha: 1.0 # (stability(0.0) <---> response(1.0))
 
   # PID Speed Control Parameters
   SpeedControl:

--- a/config.yaml
+++ b/config.yaml
@@ -181,8 +181,9 @@ control:
     max_steer_angle: 1.0
 
   Stanley:
-    k_gain: 0.7
+    k_gain: 0.6
     k_gain_curvature_boost: 1.2
+    alpha: 0.5 # (stability(0.0) <---> response(1.0))
 
   # PID Speed Control Parameters
   SpeedControl:

--- a/config.yaml
+++ b/config.yaml
@@ -83,7 +83,7 @@ perception:
     bilateral_filter_diameter: 9
 
   camera_hsv_window_size:
-    window_size: 20
+    window_size: 15
 
   # HSV thresholds for yellow cone detection
   camera_hsv_yellow:
@@ -130,7 +130,7 @@ mapping:
   cone_memory_association_threshold: 1.0
 
   # Cone sorting parameters for lane generation
-  max_connection_distance: 10.0
+  max_connection_distance: 15.0
   direction_weight: 0.5 # Path direction consistency weight (0.0 ~1.0)
 
   # Cone map refinement parameters
@@ -144,7 +144,7 @@ planning:
     # Basic trajectory generation
     lookahead_distance: 20.0
     waypoint_spacing: 0.5
-    default_speed: 3.0
+    default_speed: 3.0 # StopTrajectory
     
     # Cone-based path planning (meters)
     max_cone_distance: 25.0
@@ -182,16 +182,17 @@ control:
 
   Stanley:
     k_gain: 0.7
+    k_gain_curvature_boost: 1.5
 
   # PID Speed Control Parameters
   SpeedControl:
-    pid_kp: 0.5
-    pid_ki: 0.01
-    pid_kd: 0.02
-    max_throttle: 0.6
+    pid_kp: 0.3
+    pid_ki: 0.0
+    pid_kd: 0.01
+    max_throttle: 0.4
 
-    # Gain for steering-based speed dampening. Higher value means more aggressive slowing on turns.
-    steering_based_speed_gain: 0.2
+    # Steering-based speed dampening gain
+    steering_based_speed_gain: 0.0 # Higher value means more aggressive slowing on turns.
 
   Vehicle:
     wheel_base: 1.55

--- a/config.yaml
+++ b/config.yaml
@@ -182,7 +182,7 @@ control:
 
   Stanley:
     k_gain: 0.7
-    k_gain_curvature_boost: 1.5
+    k_gain_curvature_boost: 1.2
 
   # PID Speed Control Parameters
   SpeedControl:

--- a/formula_autonomous_system.hpp
+++ b/formula_autonomous_system.hpp
@@ -1757,6 +1757,7 @@ public:
     std::vector<TrajectoryPoint> generateTrajectoryFromCones(const std::vector<Cone>& cones, ASState planning_state);
     // Generate local trajectory by following the global path (for RACING mode)
     std::vector<TrajectoryPoint> getTrajectoryFromGlobalPath(const VehicleState& vehicle_state, const std::vector<TrajectoryPoint>& global_path);
+    std::vector<TrajectoryPoint> generateSimpleTrajectoryFromCones(const std::vector<Cone>& cones);
 
     /**
      * @brief Get last generated trajectory

--- a/formula_autonomous_system.hpp
+++ b/formula_autonomous_system.hpp
@@ -1418,6 +1418,7 @@ struct ControlParams {
     // ===================  Stanley Controller Parameters =================== 
     double k_gain_; // Stanley controller gain k
     double k_gain_curvature_boost_; // k boost depending on curvature
+    double stanley_alpha_; // Low-Pass Filter alpha
 
     // =================== Longitudinal Control: PID Controller ===================
     double pid_kp_;                    // proportional gain
@@ -1442,6 +1443,7 @@ struct ControlParams {
         // ===================  Stanley Controller Parameters =================== 
         if(!pnh.getParam("/control/Stanley/k_gain", k_gain_)){std::cerr<<"Param control/Stanley/k_gain has error" << std::endl; return false;}
         if(!pnh.getParam("/control/Stanley/k_gain_curvature_boost", k_gain_curvature_boost_)){std::cerr<<"Param control/Stanley/k_gain_curvature_boost has error" << std::endl; return false;}
+        if(!pnh.getParam("/control/Stanley/alpha", stanley_alpha_)){std::cerr<<"Param control/Stanley/alpha has error" << std::endl; return false;}
         
         // =================== Longitudinal Control: PID Controller ===================
         if(!pnh.getParam("/control/SpeedControl/pid_kp", pid_kp_)){std::cerr<<"Param control/SpeedControl/pid_kp has error" << std::endl; return false;}

--- a/formula_autonomous_system_node.cpp
+++ b/formula_autonomous_system_node.cpp
@@ -72,7 +72,7 @@ bool FormulaAutonomousSystemNode::init(){
     global_cones_marker_pub_ = nh_.advertise<visualization_msgs::MarkerArray>("/fsds/global_cones_marker", 1);
     lane_marker_pub_ = nh_.advertise<visualization_msgs::MarkerArray>("/fsds/lane_marker", 1);
     global_path_marker_pub_ = nh_.advertise<visualization_msgs::Marker>("/fsds/global_path", 1);                                // Globalpath
-    trajectory_from_global_path_marker_pub_ = nh_.advertise<visualization_msgs::Marker>("/fsds/rajectory_from_global_path", 1); // TrajectoryFromGlobalpath
+    trajectory_from_global_path_marker_pub_ = nh_.advertise<visualization_msgs::Marker>("/fsds/trajectory_from_global_path", 1); // TrajectoryFromGlobalpath
     
     // Get parameters
     pnh_.getParam("/system/main_loop_rate", main_loop_rate_);

--- a/formula_autonomous_system_node.cpp
+++ b/formula_autonomous_system_node.cpp
@@ -72,7 +72,7 @@ bool FormulaAutonomousSystemNode::init(){
     global_cones_marker_pub_ = nh_.advertise<visualization_msgs::MarkerArray>("/fsds/global_cones_marker", 1);
     lane_marker_pub_ = nh_.advertise<visualization_msgs::MarkerArray>("/fsds/lane_marker", 1);
     global_path_marker_pub_ = nh_.advertise<visualization_msgs::Marker>("/fsds/global_path", 1);                                // Globalpath
-    trajectory_from_global_path_marker_pub_ = nh_.advertise<visualization_msgs::Marker>("/fsds/trajectory_from_global_path", 1); // TrajectoryFromGlobalpath
+    trajectory_from_global_path_marker_pub_ = nh_.advertise<visualization_msgs::Marker>("/fsds/rajectory_from_global_path", 1); // TrajectoryFromGlobalpath
     
     // Get parameters
     pnh_.getParam("/system/main_loop_rate", main_loop_rate_);

--- a/formula_autonomous_system_node.cpp
+++ b/formula_autonomous_system_node.cpp
@@ -71,6 +71,8 @@ bool FormulaAutonomousSystemNode::init(){
     lap_count_marker_pub_ = nh_.advertise<visualization_msgs::MarkerArray>("/fsds/lap_count_marker", 1);
     global_cones_marker_pub_ = nh_.advertise<visualization_msgs::MarkerArray>("/fsds/global_cones_marker", 1);
     lane_marker_pub_ = nh_.advertise<visualization_msgs::MarkerArray>("/fsds/lane_marker", 1);
+    global_path_marker_pub_ = nh_.advertise<visualization_msgs::Marker>("/fsds/global_path", 1);                                // Globalpath
+    trajectory_from_global_path_marker_pub_ = nh_.advertise<visualization_msgs::Marker>("/fsds/rajectory_from_global_path", 1); // TrajectoryFromGlobalpath
     
     // Get parameters
     pnh_.getParam("/system/main_loop_rate", main_loop_rate_);
@@ -147,6 +149,9 @@ void FormulaAutonomousSystemNode::publish(){
     publishCenterLineMarker();
     publishGlobalConesMarker();
     publishLaneMarker();
+    publishStartFinishLineMarker();
+    publishGlobalPathMarker();                  // Globalpath
+    publishTrajectoryFromGlobalPathMarker();    // TrajectoryFromGlobalpath
     return;
 }
 
@@ -530,6 +535,177 @@ void FormulaAutonomousSystemNode::publishLaneMarker() {
 
     // Publish the marker array
     lane_marker_pub_.publish(marker_array);
+}
+
+// For lap counting
+
+
+
+void FormulaAutonomousSystemNode::publishStartFinishLineMarker() {
+
+    if (!formula_autonomous_system_->isStartFinishLineDefined()) {
+        return;
+    }
+    
+    // Get the current timestamp from a reliable source
+    imu_msg_mutex_.lock();
+    ros::Time current_stamp = imu_msg_.header.stamp;
+    imu_msg_mutex_.unlock();
+
+    visualization_msgs::MarkerArray marker_array;
+
+    // --- 1. Line Marker (in "map" frame) ---
+    visualization_msgs::Marker line_marker;
+    line_marker.header.frame_id = "map";
+    line_marker.header.stamp = current_stamp;
+    line_marker.ns = "start_finish_line";
+    line_marker.id = 0;
+    line_marker.type = visualization_msgs::Marker::LINE_STRIP;
+    line_marker.action = visualization_msgs::Marker::ADD;
+    line_marker.lifetime = ros::Duration(0.2);
+    line_marker.pose.orientation.w = 1.0;
+
+    // MODIFIED: Make the line thicker and orange
+    line_marker.scale.x = 0.5; // <-- CHANGE: Increased thickness
+    line_marker.color.r = 1.0; // Orange
+    line_marker.color.g = 0.5; // Orange
+    line_marker.color.b = 0.0; // Orange
+    line_marker.color.a = 1.0;
+
+    Eigen::Vector2d center = formula_autonomous_system_->getStartFinishLineCenter();
+    Eigen::Vector2d dir = formula_autonomous_system_->getStartFinishLineDirection();
+
+    double track_width = 7.0;
+
+    geometry_msgs::Point p1, p2;
+    p1.x = center.x() - dir.x() * track_width / 2.0;
+    p1.y = center.y() - dir.y() * track_width / 2.0;
+    p1.z = 0.1;
+
+    p2.x = center.x() + dir.x() * track_width / 2.0;
+    p2.y = center.y() + dir.y() * track_width / 2.0;
+    p2.z = 0.1;
+
+    line_marker.points.push_back(p1);
+    line_marker.points.push_back(p2);
+    marker_array.markers.push_back(line_marker);
+
+    // --- 2. Text Marker for Lap Count (in "fsds/FSCar" vehicle frame) ---
+    visualization_msgs::Marker text_marker;
+    text_marker.header.frame_id = "fsds/FSCar";
+    text_marker.header.stamp = current_stamp;
+    text_marker.ns = "lap_count_text";
+    text_marker.id = 1;
+    text_marker.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
+    text_marker.action = visualization_msgs::Marker::ADD;
+    text_marker.lifetime = ros::Duration(0.2);
+    text_marker.pose.position.x = 4.0;
+    text_marker.pose.position.y = 4.0;
+    text_marker.pose.position.z = 4.0;
+    text_marker.pose.orientation.w = 1.0;
+    text_marker.scale.z = 0.8;
+
+    // MODIFIED: Make the text green
+    text_marker.color.r = 0.0; // Green
+    text_marker.color.g = 1.0; // Green
+    text_marker.color.b = 0.0; // Green
+    text_marker.color.a = 1.0;
+
+    int total_laps = 10;
+    std::stringstream ss;
+    ss << "Lap: " << formula_autonomous_system_->getCurrentLap() << " / " << total_laps;
+    text_marker.text = ss.str();
+    marker_array.markers.push_back(text_marker);
+    lap_count_marker_pub_.publish(marker_array);
+}
+
+// Globalpath
+void FormulaAutonomousSystemNode::publishGlobalPathMarker() {
+
+    if (!formula_autonomous_system_->isGlobalPathGenerated()) {
+        return; // Don't publish if the path doesn't exist yet
+    }
+
+    auto global_path = formula_autonomous_system_->getGlobalPath();
+
+    if (global_path.empty()) {
+        return;
+    }
+
+    // Get header from a reliable source
+    imu_msg_mutex_.lock();
+    std_msgs::Header header = imu_msg_.header;
+    imu_msg_mutex_.unlock();
+    header.frame_id = "map"; // The global path is in the "map" frame
+    visualization_msgs::Marker path_marker;
+    path_marker.header = header;
+    path_marker.ns = "global_path";
+    path_marker.id = 0;
+    path_marker.type = visualization_msgs::Marker::LINE_STRIP;
+    path_marker.action = visualization_msgs::Marker::ADD;
+    path_marker.lifetime = ros::Duration(); // A duration of 0 means it persists forever
+    path_marker.pose.orientation.w = 1.0;
+    path_marker.scale.x = 0.15; // Line width
+    path_marker.color.r = 0.0;  // Cyan color for distinction
+    path_marker.color.g = 1.0;
+    path_marker.color.b = 1.0;
+    path_marker.color.a = 0.8;  // Slightly transparent
+
+    for (const auto& point : global_path) {
+
+        geometry_msgs::Point p;
+        p.x = point.position.x();
+        p.y = point.position.y();
+        p.z = 0.1; // Draw it slightly above the ground to avoid z-fighting
+        path_marker.points.push_back(p);
+    }
+
+    global_path_marker_pub_.publish(path_marker);
+}
+
+// GlobalpathTrajectory
+void FormulaAutonomousSystemNode::publishTrajectoryFromGlobalPathMarker() { 
+
+    if (!formula_autonomous_system_->isGlobalPathGenerated()) {
+        return;
+    }
+
+    auto local_points = formula_autonomous_system_->getTrajectoryGenerator()->getLastLocalPathPoints();
+
+    if (local_points.empty()) {
+        return;
+    }
+
+    imu_msg_mutex_.lock();
+    std_msgs::Header header = imu_msg_.header;
+    imu_msg_mutex_.unlock();
+    header.frame_id = "fsds/FSCar";
+    visualization_msgs::Marker points_marker;
+    points_marker.header = header;
+    points_marker.ns = "trajectory_from_global_path"; 
+    points_marker.id = 0;
+    points_marker.type = visualization_msgs::Marker::SPHERE_LIST;
+    points_marker.action = visualization_msgs::Marker::ADD;
+    points_marker.lifetime = ros::Duration(0.1);
+    points_marker.pose.orientation.w = 1.0;
+    points_marker.scale.x = 0.2;
+    points_marker.scale.y = 0.2;
+    points_marker.scale.z = 0.2;
+    points_marker.color.r = 1.0;
+    points_marker.color.g = 0.0;
+    points_marker.color.b = 0.0;
+    points_marker.color.a = 1.0;
+
+    for (const auto& point : local_points) {
+
+        geometry_msgs::Point p;
+        p.x = point.x();
+        p.y = point.y();
+        p.z = 0.2;
+        points_marker.points.push_back(p);
+    }
+
+    trajectory_from_global_path_marker_pub_.publish(points_marker); 
 }
 
 int main(int argc, char** argv){

--- a/formula_autonomous_system_node.hpp
+++ b/formula_autonomous_system_node.hpp
@@ -211,5 +211,4 @@ public: // ROS
     std::unique_ptr<FormulaAutonomousSystem> formula_autonomous_system_;
 };
 
-
 #endif // FORMULA_AUTONOMOUS_SYSTEM_NODE_HPP

--- a/formula_autonomous_system_node.hpp
+++ b/formula_autonomous_system_node.hpp
@@ -137,7 +137,9 @@ public: // Function components
     void publishCenterLineMarker();
     void publishGlobalConesMarker();
     void publishLaneMarker();
-    
+    void publishStartFinishLineMarker();
+    void publishGlobalPathMarker();                  // Globalpath
+    void publishTrajectoryFromGlobalPathMarker();    // TrajectoryFromGlobalpath
 
 // Variables
 private:
@@ -192,6 +194,8 @@ public: // ROS
     ros::Publisher lap_count_marker_pub_;
     ros::Publisher global_cones_marker_pub_;
     ros::Publisher lane_marker_pub_;
+    ros::Publisher global_path_marker_pub_;                    // Globalpath
+    ros::Publisher trajectory_from_global_path_marker_pub_;    // TrajectoryFromGlobalpath
 
     // Output messages
     fs_msgs::ControlCommand control_command_msg_;


### PR DESCRIPTION
이번 커밋은 자율주행 시스템의 안정성과 성능을 대폭 향상시키기 위한 핵심적인 구조 개선을 포함합니다. MAPPING 모드와 RACING 모드의 역할을 명확히 분리하고, 각 모드의 목표에 최적화된 로직과 파라미터를 적용하는 데 중점을 두었습니다.

1. 주행 모드별 파라미터 분리 (config.yaml, .hpp)

- 구조 개선: config.yaml의 planning 섹션을 trajectory_generation과 behavioral_logic으로 재구성하여 역할과 계층을 명확히 했습니다.

- 독립적 튜닝: trajectory_generation 하위에 mapping_mode와 racing_mode 섹션을 분리하여, 각 모드의 lookahead_distance, max_speed 등을 독립적으로 설정할 수 있도록 변경했습니다.

- 코드 반영: C++의 PlanningParams 구조체를 새로운 yaml 계층에 맞춰 수정하여, 모드별 파라미터를 체계적으로 불러오고 관리할 수 있도록 개선했습니다.

2. MAPPING 모드 경로 생성 로직 교체

- 안정성 최우선: 주행 안정성이 가장 뛰어났던 generatePathFromClosestCones (구 generateSimpleTrajectoryFromCones)를 MAPPING 모드의 표준 경로 생성 로직으로 채택했습니다.

- 불필요한 로직 제거: 진동을 유발했던 기존의 복잡한 스플라인 기반 실시간 경로 생성 함수(generateTrajectoryFromCones)는 프로젝트에서 완전히 삭제하여 코드 복잡성을 줄였습니다.

- 기대 효과: MAPPING 랩 동안의 주행 안정성을 극대화하여, RACING 모드에서 사용할 전역 맵의 품질과 정확도를 크게 향상시켰습니다.

3. 전역 경로(Global Path) 생성 로직 고도화

- 곡률 및 속도 사전 계산: MAPPING 랩이 끝난 후 generateGlobalPath 함수가 호출될 때, 이제 트랙의 중앙점을 부드러운 스플라인으로 연결할 뿐만 아니라, 경로의 모든 지점에 대한 곡률(Curvature)과 목표 주행 속도를 미리 계산하여 global_path_에 함께 저장합니다.

- 지능적 속도 계획: 곡률이 큰 코너에서는 min_speed에 가깝게, 직선 주로에서는 max_speed에 가깝게 목표 속도가 자동으로 설정됩니다.

4. RACING 모드 경로 추종 로직 효율화

- 경량화: getTrajectoryFromGlobalPath 함수는 더 이상 매 순간 무거운 스플라인 계산을 반복하지 않습니다.

- 단순 좌표 변환: 대신, 모든 정보가 미리 계산된 global_path_에서 현재 필요한 경로 조각을 가져와 단순히 차량의 지역 좌표계로 변환하는 매우 가볍고 빠른 로직으로 변경되었습니다. 이로써 제어 주기를 안정적으로 확보할 수 있습니다.